### PR TITLE
Keep GraphQL rich snippets on ordinary Product (opt out of ProductGroup)

### DIFF
--- a/Model/Resolver/Markup/RichSnippets/Product.php
+++ b/Model/Resolver/Markup/RichSnippets/Product.php
@@ -91,7 +91,8 @@ class Product implements ResolverInterface
             \MageWorx\SeoMarkup\Block\Head\Json\Product::class,
             '',
             [
-                'data' => []
+                // ProductGroup markup is single-page/storefront-only in v1; keep GraphQL on ordinary Product.
+                'data' => ['allow_product_group' => false]
             ]
         );
         $block->setEntity($product);


### PR DESCRIPTION
Companion to the ProductGroup markup added in `MageWorx_SeoMarkup` (`summer_update`).

The new Product Group mode applies to storefront/REST JSON-LD only. This keeps the GraphQL resolver on the ordinary single-`Product` rich snippets, so GraphQL output is unaffected by the ProductGroup markup mode.

- `Model/Resolver/Markup/RichSnippets/Product.php` — opt GraphQL out of ProductGroup (1 file, +2/−1).
- No schema or breaking changes.