### PR TITLE
Reset the product markup state after frontend emulation

### DIFF
--- a/Model/Resolver/Markup/RichSnippets/Product.php
+++ b/Model/Resolver/Markup/RichSnippets/Product.php
@@ -19,6 +19,7 @@ use Magento\Framework\App\Area;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Catalog\Api\Data\ProductAttributeInterface;
 use MageWorx\SeoMarkup\Helper\Product as HelperProduct;
+use MageWorx\SeoMarkup\Model\Product\MarkupState;
 
 class Product implements ResolverInterface
 {
@@ -43,23 +44,31 @@ class Product implements ResolverInterface
     protected $helperProduct;
 
     /**
+     * @var MarkupState|null
+     */
+    protected $markupState;
+
+    /**
      * Product constructor.
      *
      * @param LayoutFactory $layoutFactory
      * @param State $appState
      * @param CollectionFactory $productCollectionFactory
      * @param HelperProduct $helperProduct
+     * @param MarkupState|null $markupState
      */
     public function __construct(
         LayoutFactory $layoutFactory,
         State $appState,
         CollectionFactory $productCollectionFactory,
-        HelperProduct $helperProduct
+        HelperProduct $helperProduct,
+        ?MarkupState  $markupState = null
     ) {
         $this->layoutFactory            = $layoutFactory;
         $this->appState                 = $appState;
         $this->productCollectionFactory = $productCollectionFactory;
         $this->helperProduct            = $helperProduct;
+        $this->markupState              = $markupState;
     }
 
     /**
@@ -97,7 +106,14 @@ class Product implements ResolverInterface
         );
         $block->setEntity($product);
 
-        return $this->appState->emulateAreaCode(Area::AREA_FRONTEND, [$block, 'toHtml']);
+        try {
+            return $this->appState->emulateAreaCode(Area::AREA_FRONTEND, [$block, 'toHtml']);
+        } finally {
+            // Frontend emulation activates the storefront cleanup; keep it out of the rest of the query.
+            if ($this->markupState) {
+                $this->markupState->reset();
+            }
+        }
     }
 
     /**

--- a/Model/Resolver/Markup/RichSnippets/Product.php
+++ b/Model/Resolver/Markup/RichSnippets/Product.php
@@ -147,6 +147,7 @@ class Product implements ResolverInterface
         ];
 
         if ($this->helperProduct->isUseSpecialPriceFunctionality()) {
+            $attributes[] = 'special_price';
             $attributes[] = 'special_from_date';
             $attributes[] = 'special_to_date';
         }

--- a/Test/Unit/Model/Resolver/Markup/RichSnippets/ProductTest.php
+++ b/Test/Unit/Model/Resolver/Markup/RichSnippets/ProductTest.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace MageWorx\SeoMarkupGraphQl\Test\Unit\Model\Resolver\Markup\RichSnippets;
+
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\App\State;
+use Magento\Framework\View\LayoutFactory;
+use MageWorx\SeoMarkup\Helper\Product as HelperProduct;
+use MageWorx\SeoMarkupGraphQl\Model\Resolver\Markup\RichSnippets\Product as ProductResolver;
+use PHPUnit\Framework\TestCase;
+
+class ProductTest extends TestCase
+{
+    public function testAttributesForCollectionIncludeSpecialPriceAttributes(): void
+    {
+        $helperProduct = $this->createMock(HelperProduct::class);
+        $helperProduct->method('isUseSpecialPriceFunctionality')->willReturn(true);
+
+        $resolver = new class (
+            $this->createMock(LayoutFactory::class),
+            $this->createMock(State::class),
+            $this->createMock(CollectionFactory::class),
+            $helperProduct
+        ) extends ProductResolver {
+            public function getAttributes(): array
+            {
+                return $this->getAttributesForCollection();
+            }
+        };
+
+        $attributes = $resolver->getAttributes();
+
+        self::assertContains('special_price', $attributes);
+        self::assertContains('special_from_date', $attributes);
+        self::assertContains('special_to_date', $attributes);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -18,5 +18,5 @@
             "MageWorx\\SeoMarkupGraphQl\\": ""
         }
     },
-    "version": "1.2.1"
+    "version": "1.2.2"
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © MageWorx. All rights reserved.
+ * See LICENSE.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <type name="MageWorx\SeoMarkupGraphQl\Model\Resolver\Markup\RichSnippets\Product">
+        <arguments>
+            <argument name="markupState" xsi:type="object">MageWorx\SeoMarkup\Model\Product\MarkupState</argument>
+        </arguments>
+    </type>
+</config>


### PR DESCRIPTION
The resolver renders the head JSON-LD block through `emulateAreaCode(AREA_FRONTEND)`. Frontend emulation also activates the storefront markup cleanup, so the block leaves behind the flag that cleanup reads. Without a reset the flag survives for the rest of the query, and a later resolver rendering any block under emulation would have its microdata stripped from the GraphQL response. In a multi-product query the flag was also last-write-wins across products.

The flag is now cleared in a `finally` right after emulation ends. The new constructor argument is optional and wired explicitly in `etc/di.xml` — Magento does not auto-wire optional arguments.

The GraphQL product collection now also loads `special_price` together with the special-price dates. This lets the shared product JSON-LD renderer emit `Offer.validFrom` only when Magento confirms that the active special price is the published final price and its sale period is valid.

Requires MageWorx_SeoMarkup !80.

Reported: https://mageworx.zendesk.com/agent/tickets/166050